### PR TITLE
🐛 Fix: 일반 Api 응답 불량 이슈 (검색은 추가 수정 필요)

### DIFF
--- a/src/main/java/com/promptoven/profileservice/adaptor/web/controller/ProfileRestController.java
+++ b/src/main/java/com/promptoven/profileservice/adaptor/web/controller/ProfileRestController.java
@@ -1,5 +1,7 @@
 package com.promptoven.profileservice.adaptor.web.controller;
 
+import java.util.List;
+
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -82,15 +84,17 @@ public class ProfileRestController {
 	}
 
 	@GetMapping("/profile/nickname/{nickname}/following")
-	public BaseResponse<ProfileResponseVO> getFollowingByNickname(@PathVariable String nickname) {
-		followingUsecase.getFollowing(nickname);
-		return new BaseResponse<>(null);
+	public BaseResponse<List<ProfileShortResponseVO>> getFollowingByNickname(@PathVariable String nickname) {
+		return new BaseResponse<>(followingUsecase.getFollowing(nickname).stream()
+			.map(ProfileResponseMapper::toShortVO)
+			.toList());
 	}
 
 	@GetMapping("/profile/nickname/{nickname}/follower")
-	public BaseResponse<ProfileResponseVO> getFollowerByNickname(@PathVariable String nickname) {
-		followingUsecase.getFollowers(nickname);
-		return new BaseResponse<>(null);
+	public BaseResponse<List<ProfileShortResponseVO>> getFollowerByNickname(@PathVariable String nickname) {
+		return new BaseResponse<>(followingUsecase.getFollowers(nickname).stream()
+			.map(ProfileResponseMapper::toShortVO)
+			.toList());
 	}
 
 	@GetMapping("/profile/uuid/{memberUUID}/short")

--- a/src/main/java/com/promptoven/profileservice/adaptor/web/controller/vo/out/ProfileResponseVO.java
+++ b/src/main/java/com/promptoven/profileservice/adaptor/web/controller/vo/out/ProfileResponseVO.java
@@ -4,9 +4,11 @@ import java.time.LocalDateTime;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 
 @AllArgsConstructor
 @Builder
+@Getter
 public class ProfileResponseVO {
 	private final String memberUUID;
 	private final String bannerImageUrl;

--- a/src/main/java/com/promptoven/profileservice/adaptor/web/controller/vo/out/ProfileSearchResponseVO.java
+++ b/src/main/java/com/promptoven/profileservice/adaptor/web/controller/vo/out/ProfileSearchResponseVO.java
@@ -2,9 +2,11 @@ package com.promptoven.profileservice.adaptor.web.controller.vo.out;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 
 @AllArgsConstructor
 @Builder
+@Getter
 public class ProfileSearchResponseVO {
 
 	private final String thumbnail;

--- a/src/main/java/com/promptoven/profileservice/adaptor/web/controller/vo/out/ProfileShortResponseVO.java
+++ b/src/main/java/com/promptoven/profileservice/adaptor/web/controller/vo/out/ProfileShortResponseVO.java
@@ -2,13 +2,15 @@ package com.promptoven.profileservice.adaptor.web.controller.vo.out;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 
 @AllArgsConstructor
 @Builder
+@Getter
 public class ProfileShortResponseVO {
 
 	private final String memberUuid;
 	private final String memberProfileImage;
 	private final String memberNickname;
-	
+
 }

--- a/src/main/java/com/promptoven/profileservice/application/service/ProfileViewershipService.java
+++ b/src/main/java/com/promptoven/profileservice/application/service/ProfileViewershipService.java
@@ -37,7 +37,7 @@ public class ProfileViewershipService implements ProfileViewershipUsecase {
 	@Override
 	public void applyViewCounts(String profileId) {
 		Long accumulatedCount = profileViewershipMemory.getAndResetViewCount(profileId);
-		if (accumulatedCount > 0) {
+		if (null != accumulatedCount && accumulatedCount > 0) {
 			profileStatisticsPersistence.addProfileViewCount(profileId, accumulatedCount);
 		}
 	}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -118,5 +118,3 @@ eureka:
 logging:
   level:
     com.promptoven.profileservice.adaptor.redis: DEBUG
-
-


### PR DESCRIPTION
This pull request includes several changes to the `ProfileRestController` and related services to improve response handling and null safety checks. The most important changes include updating the response types for follower and following endpoints, adding null checks in the view count application, and cleaning up configuration files.

Changes to response handling:

* [`src/main/java/com/promptoven/profileservice/adaptor/web/controller/ProfileRestController.java`](diffhunk://#diff-e1607d5ea52c0dadb79057074e63b48bb764a27540d1198c68c7de8da8dc1f1aL85-R97): Updated the `getFollowingByNickname` and `getFollowerByNickname` methods to return a list of `ProfileShortResponseVO` instead of a single `ProfileResponseVO`. This change ensures that the endpoints return a list of profiles, improving the clarity and usability of the API.

Null safety improvements:

* [`src/main/java/com/promptoven/profileservice/application/service/ProfileViewershipService.java`](diffhunk://#diff-25ae9b3454c551b09af2bebcea2c59a747e7181802ddc7c149bd6e67495062dcL40-R40): Added a null check for `accumulatedCount` in the `applyViewCounts` method to prevent potential null pointer exceptions.

Configuration cleanup:

* [`src/main/resources/application.yaml`](diffhunk://#diff-b4c0421bcb3280a8e738550c830dba197057c515bcdd9579a52cbfe9adca2061L121-L122): Removed unnecessary blank lines in the YAML configuration file for better readability.